### PR TITLE
Fixed scroll doesn't stop at the right position

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -83,7 +83,7 @@
 				// Stop animation when you reach the anchor OR the top of the page
 				stopAnimation = function () {
 					var travelled = window.pageYOffset;
-					if ( travelled <= endLocation(anchor) || travelled <= 0 ) {
+					if ( travelled <= endLocation(anchor) + 1 || travelled <= 0 ) {
 						clearInterval(runAnimation);
 					}
 				};


### PR DESCRIPTION
This fix make sure that the scroll will stop at the right position after the animation.
