### PR TITLE
Fix back button when using the data-url feature

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -140,6 +140,6 @@
 		if (event.state === null && window.location.hash === "") {
 			window.scrollTo(0,0);
 		}
-    };
+	};
 
 })();


### PR DESCRIPTION
Hello again!

As we discussed on #17, here's the fix for the back button. Thanks for taking time with this!

_Pseudo code:_
1. Page loads. Chrome/Safari fire **onpopstate** event, Firefox doesn't.
2. User clicks a smooth scroll link, is scrolled to it, and the URL is updated.
3. User clicks back.
   - Browser removes the URL fragment that was added.
   - Browser fires **onpopstate** with a default event.
   - My code sees the event is the default event and sends the user to the top.

_Other notes:_

I updated your **history.pushState** so it creates events with unique info.

As before, clicking multiple smooth scroll links will update the URL fragment each time. Clicking back between them changes the URL and position to the previous fragment. So *_onpopstate_ isn't needed in this case, even though it still fires.
## Test cases

**Test A:**
1. load the page
2. click a smooth scroll link
3. click back

_Page position should be at the top of the page._

**Test B:**
1. load page
2. click smooth scroll link
3. go to a different page or website
4. click back

_Page position should be the same as when you left the smooth scroll page._

**Test C:**
1. load page
2. scroll down manually to a smooth scroll link and click it
3. click back

_Page position should be at the top of the page. (Some may prefer that the position return to where you clicked the link. I understand, but that's hard  and this behavior is still better than the back button doing nothing.)_

**Test D:**
1. load page with a url fragment, i.e. #bazinga

_Page should load with the #bazinga element at the top._
