### PR TITLE
Added fixed header option

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -63,7 +63,10 @@
 						anchor = anchor.offsetParent;
 					} while (anchor);
 				}
-				return distance;
+				// optional fixed header offset
+				var scrollHeader = document.querySelector( '.scroll-header' );
+				var headerHeight = scrollHeader === null ? 0 : scrollHeader.offsetHeight;
+				return distance - headerHeight;
 			};
 			var distance = endLocation(anchor) - startLocation;
 			var increments = distance / (duration / 16);


### PR DESCRIPTION
Websites using a fixed navigation bar can add the class "fixed-header" to the navigation element to offset the end of the scrolling animation at the right position - and not as default at the top of the page.
