### PR TITLE
Fixed negative endLocation bug

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -72,12 +72,12 @@
 				return distance - headerHeight;
 			};
 			var endLocation = getEndLocation(anchor);
+			endLocation = endLocation < 0 ? 0 : endLocation;
 			var distance = endLocation - startLocation;
 
 			// Function to stop the scrolling animation
 			var stopAnimation = function () {
 				var currentLocation = window.pageYOffset;
-				// var there = endLocation(anchor);
 				if ( currentLocation == endLocation || ( (window.innerHeight + currentLocation) >= document.body.scrollHeight ) ) {
 					clearInterval(runAnimation);
 					updateURL(url, anchor);


### PR DESCRIPTION
On sites using tht optional fixed header ('scrollHeader') an anchor might be placed above the fixed header. This leads to an negative 'endLocation' and therefore the interval 'runAnimation' will not be cleared.
