### PR TITLE
Update URL before animation

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -51,7 +51,7 @@
 			// Function to update URL
 			var updateURL = function (url, anchor) {
 				if ( url === 'true' && history.pushState ) {
-					window.location.hash = '#' + anchor.id;
+					history.pushState(null, null, '#' + anchor.id);
 				}
 			};
 


### PR DESCRIPTION
Instead of waiting for the animation to stop before updating the URL, let’s update it right off the bat.

I’m using `nav:target` to show/hide my main menu on touch devices using only CSS. One of the benefits of this is that as soon as a menu item is tapped, the menu is hidden because the URL changes. Enter smooth-scroll: Because the script waits until the animation stops before updating the URL, the menu stays visible while the script animates the scroll to the selected location, and **only then** closes. This looks awkward.

This commit changes the order of things, so that the URL is changed immediately, making my menu toggle at the expected time (immediately after tapping a menu item).

Let me know if you would prefer a more robust solution that offers both options. For example: dataURL could have the values `before`, `after`, and `false`, so developers have more control over this behavior. I’d like to take a crack at that if it’s something you’d like to see.

Thanks!
