### PR TITLE
Added support for custom fixed header height

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -44,7 +44,11 @@ window.smoothScroll = (function (window, document, undefined) {
 
 			// Get the height of a fixed header if one exists
 			var scrollHeader = document.querySelector('[data-scroll-header]');
-			var headerHeight = scrollHeader === null ? 0 : scrollHeader.offsetHeight;
+			var headerHeight = 0;
+			if ( scrollHeader !== null ) {
+				var headerOverride = scrollHeader.getAttribute('data-scroll-header');
+				headerHeight = headerOverride === "" ? scrollHeader.offsetHeight : headerOverride;
+			}
 
 			// Set the animation variables to 0/undefined.
 			var timeLapsed = 0;


### PR DESCRIPTION
Defining a value for `data-scroll-header` overrides calculated `scrollHeader.offsetHeight`. 
Sometimes this is more versatile than depending on `.offsetHeight` which e.g. doesn't include margins. I know the "fixed header option" it's not your main goal for the script but I use it all the time. Switching to data-attributes makes it really elegant to include this feature. So maybe you could include it for everyone to use… Thanks!
