### PR TITLE
Fix iOS stuck in infinite loop bug

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -99,7 +99,7 @@ window.smoothScroll = (function (window, document, undefined) {
 			// Stop the scrolling animation when the anchor is reached (or at the top/bottom of the page)
 			var stopAnimation = function () {
 				var currentLocation = window.pageYOffset;
-				if ( currentLocation == endLocation || ( (window.innerHeight + currentLocation) >= document.body.scrollHeight ) ) {
+				if ( position == endLocation || currentLocation == endLocation || ( (window.innerHeight + currentLocation) >= document.body.scrollHeight ) ) {
 					clearInterval(runAnimation);
 				}
 			};


### PR DESCRIPTION
A few iOS tests showed that the `scrollTo` function isn't exactly "pixel perfect" on iOS devices, and may produce an infinite loop (seems to be the cause of issue #34 as well).

This fix forces the animation loop to stop if it is calling the last iteration of `animateScroll`.
