### PR TITLE
Add offsettTop to offsetHeight for scrollHeader

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -47,7 +47,7 @@ window.smoothScroll = (function (window, document, undefined) {
 
 			// Get the height of a fixed header if one exists
 			var scrollHeader = document.querySelector('[data-scroll-header]');
-			var headerHeight = scrollHeader === null ? 0 : scrollHeader.offsetHeight;
+			var headerHeight = scrollHeader === null ? 0 : (scrollHeader.offsetHeight + scrollHeader.offsetTop);
 
 			// Set the animation variables to 0/undefined.
 			var timeLapsed = 0;


### PR DESCRIPTION
If you have multiple fixed headers, it’s not enough to calculate the headerHeight as the height of the sticky header element. We need to add the offsetTop to compensate for the first sticky header.

If this is a general behavior that should be included in the smooth-scroll lib I'm not sure - sending this PR as a suggestion to a scenario you might have to consider. That beeing said, it shouldn't be a problem, as the offsetTop will be 0 for users/sites with a singly sticky header.
