### PR TITLE
Pass element that triggered smoothScroll to callbacks

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -145,7 +145,7 @@ window.smoothScroll = (function (window, document, undefined) {
 			var currentLocation = window.pageYOffset;
 			if ( position == endLocation || currentLocation == endLocation || ( (window.innerHeight + currentLocation) >= document.body.scrollHeight ) ) {
 				clearInterval(animationInterval);
-				options.callbackAfter(); // Run callbacks after animation complete
+				options.callbackAfter(toggle); // Run callbacks after animation complete
 			}
 		};
 
@@ -165,7 +165,7 @@ window.smoothScroll = (function (window, document, undefined) {
 		// Private method
 		// Runs functions
 		var _startAnimateScroll = function () {
-			options.callbackBefore(); // Run callbacks before animating scroll
+			options.callbackBefore(toggle); // Run callbacks before animating scroll
 			animationInterval = setInterval(_loopAnimateScroll, 16);
 		};
 


### PR DESCRIPTION
Changed code so that DOM element that triggered smoothScroll is passed to callbacks. You can now write conditional code in the callback based on which element triggered the scroll. An example would be to focus an input after scrolling to it's container.
