### PR TITLE
Added .reinit() function for rebuilding click listeners

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -206,7 +206,8 @@ window.smoothScroll = (function (window, document, undefined) {
 	// Initialize Smooth Scroll
 	// Public method
 	// Runs functions
-	var init = function ( options ) {		
+	var init = function ( options ) {
+		
 		// call reinit with the provided values
 		reinit(options);
 	};
@@ -252,7 +253,7 @@ window.smoothScroll = (function (window, document, undefined) {
 				toggle.addEventListener('click', listener, false);
 			});
 		}
-	}
+	};
 
 	// Return public methods
 	return {


### PR DESCRIPTION
reinit() can be used to rebuild click listeners, after new links were added
or link targets changed.

The script now keeps track of assigned event listeners and removes them
prior to assigning new ones, to avoid listener stacking.
