### PR TITLE
Call factory with context, otherwise missing

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -12,7 +12,7 @@
 
 (function (root, factory) {
 	if ( typeof define === 'function' && define.amd ) {
-		define(factory(root));
+		define('smooth-scroll', factory(root));
 	} else if ( typeof exports === 'object' ) {
 		module.exports = factory(root);
 	} else {


### PR DESCRIPTION
Within factory root would be localRequire in the case of an AMD or UMD definition (first two conditionals). To fix this we call the factory with the proper root in such cases.
