### PR TITLE
Removes anchors first slash, if any

### DIFF
--- a/smooth-scroll.js
+++ b/smooth-scroll.js
@@ -195,6 +195,7 @@
 	exports.animateScroll = function ( toggle, anchor, options, event ) {
 
 		// Options and overrides
+		var anchor = anchor.replace(/^\//, '');
 		var settings = extend( defaults, options || {} ); // Merge user options with defaults
 		var overrides = getDataOptions( toggle ? toggle.getAttribute('data-options') : null );
 		settings = extend( settings, overrides );


### PR DESCRIPTION
Hi, first of all, thank you for the great script.

I like to use some links with the slash (/#anchor-a). So I just removed the slash, this way I can use smooth-scroll.

You can see it live on http://mmowe.com

Thanks
