### PR TITLE
Added an option to skip updating the URL

### DIFF
--- a/src/js/smooth-scroll.js
+++ b/src/js/smooth-scroll.js
@@ -288,7 +288,7 @@
 		var percentage, position;
 
 		// Update URL
-		updateUrl(anchor, settings.updateURL);
+		if ( !settings.skipUpdateUrl ) updateUrl(anchor, settings.updateURL);
 
 		/**
 		 * Stop the scroll animation when it reaches its target (or the bottom/top of page)


### PR DESCRIPTION
In my particular use of this library I don't want to actually update the url, I just want to scroll to a location on the screen. Changing the URL reloads the page and ruins things. Since the default behavior of the library is to update the URL, the option I've added is one to skip instead of forcing the dev to enable it every time.