### PR TITLE
fix: don't scroll if the url points elsewhere

### DIFF
--- a/src/js/smooth-scroll.js
+++ b/src/js/smooth-scroll.js
@@ -430,6 +430,11 @@
 		// If a smooth scroll link, animate it
 		var toggle = getClosest( event.target, settings.selector );
 		if ( toggle && toggle.tagName.toLowerCase() === 'a' ) {
+			
+			if (toggle.origin !== location.origin || toggle.pathname !== location.pathname) {
+        			return;
+      			}
+
 			event.preventDefault(); // Prevent default click event
 			var hash = smoothScroll.escapeCharacters( toggle.hash ); // Escape hash characters
 			smoothScroll.animateScroll( hash, toggle, settings); // Animate scroll


### PR DESCRIPTION
If the element has the `data-scroll` property, but also doesn't link internally, the URL doesn't click through anymore (i.e. broken). This change checks that the link clicked points to an internal URL.