### PR TITLE
Cross-browser compatible getDocumentHeight implementation

### DIFF
--- a/src/js/smooth-scroll.js
+++ b/src/js/smooth-scroll.js
@@ -203,7 +203,11 @@
 	 * @returns {Number}
 	 */
 	var getDocumentHeight = function () {
-		return parseInt(window.getComputedStyle(document.documentElement).height, 10);
+    return Math.max(
+        document.body.scrollHeight, document.documentElement.scrollHeight,
+        document.body.offsetHeight, document.documentElement.offsetHeight,
+        document.body.clientHeight, document.documentElement.clientHeight
+    );
 	};
 
 	/**


### PR DESCRIPTION
I've run into an issue in Chrome 60 and Firefox 55 on Linux (haven't got time to test the issue on other browsers or platforms).

The following code:
`window.getComputedStyle(document.documentElement).height`
Always returns WINDOW (viewport) height instead of document height (eg. if actual document content height is 4000px, but the viewport height is only 900px, this code returns 900 instead of 4000.

This results in immediate termination at line 343 in function stopAnimateScroll:
```
position == endLocation || currentLocation == endLocation || ((startLocation < endLocation && window.innerHeight + currentLocation) >= documentHeight )
```

since innerHeight property of window (incremented by current location, which is always 0 or more) is always at least the size of the window (900px in the example above), the same value that is set to documentHeight variable at line 327 (900px in the example, meaning `900 >= 900` will always true).

Suggested replacement uses cross-browser compatible solution to acquire actual document height instead of window height.

_I didn't run gulp build on this pull request, only updated files in `src`._