### PR TITLE
added feature detect for event.target.closest to prevent firefox error

### DIFF
--- a/src/js/smooth-scroll.js
+++ b/src/js/smooth-scroll.js
@@ -424,6 +424,9 @@
 			// Don't run if right-click or command/control + click
 			if (event.button !== 0 || event.metaKey || event.ctrlKey) return;
 
+			// Check if event.target has closest method
+			if(!'closest' in event.target)return;
+			
 			// Check if a smooth scroll link was clicked
 			toggle = event.target.closest(selector);
 			if (!toggle || toggle.tagName.toLowerCase() !== 'a' || event.target.closest(settings.ignore)) return;


### PR DESCRIPTION
We've seen a lot of 'event.target.closest is not a function' in sentry lately coming from the smooth-scroll clickhandler.
If a draggable is released outside the window firefox returns HTMLDocument wich does not have the closest function.  
I've added a feature detect to get rid of the errors.