### PR TITLE
fix #411 protect the ID from overwrite

### DIFF
--- a/src/js/smooth-scroll.js
+++ b/src/js/smooth-scroll.js
@@ -438,6 +438,11 @@
 				hash = escapeCharacters(toggle.hash);
 			}
 
+			// If anchor is not empty, protect the anchor element's ID from overwrite
+			if (anchor) {
+				anchor.id = anchor.getAttribute('data-scroll-id');
+			}
+
 			// If the hash is empty, scroll to the top of the page
 			if (hash === '#') {
 


### PR DESCRIPTION
Bug fixed :
If a clickHandler is called more than twice before a hashChangeHandler, in rare case those element's ID of not referenced from latest anchor will be lost.