### PR TITLE
fix: make sure history.state exists in popstatehandler

### DIFF
--- a/src/js/smooth-scroll.js
+++ b/src/js/smooth-scroll.js
@@ -518,6 +518,9 @@
 		 * Animate scroll on popstate events
 		 */
 		var popstateHandler = function (event) {
+			// Stop if history.state doesn't exist (ex. if clicking on a broken anchor link).
+			// fixes `Cannot read property 'smoothScroll' of null` error getting thrown.
+			if (history.state === null) return; 
 
 			// Only run if state is a popstate record for this instantiation
 			if (!history.state.smoothScroll || history.state.smoothScroll !== JSON.stringify(settings)) return;


### PR DESCRIPTION
1. Fixes a JavaScript error we keep encountering if you click on an anchor link on a page that doesn't have a corresponding element with that ID.

For example:
```
<a href="#broken">Broken on v14.2</a>

<div id="broke">
<p>Having a mis-matched ID than the one trying to be smooth-scrolled to OR not having an element exist at all, throws a `Cannot read property 'smoothScroll' of null` error.</p> 

<p>This even happens when smoothScroll is told NOT to select the problematic link.</p>
</div>
```

2. demo of this happening (first link works, second link throws the error): https://jsfiddle.net/ptkfs5y4/5/

3. First saw this on Chrome 67, MacOS (although we're seeing this in other browsers as well)

CC @remydenton